### PR TITLE
Draft: Issue with VERA Problem 3B OpenMC inputs

### DIFF
--- a/v2o/__main__.py
+++ b/v2o/__main__.py
@@ -255,8 +255,11 @@ class Conversion:
 		self._max_batches = max_batches
 		self.folder = folder
 		
-		## FIXME: I think this is where the problem is ##
-		self._pwr_assembly0 = None
+		###################################################
+		# FIXME: This does the first assembly encountered #
+		###################################################
+		if len(self._case.assemblies) > 1:
+			raise RuntimeError(f"Multiple assembly definitions found: {self._case.assemblies}. Aborting.")
 		self._assembly0 = list(self._case.assemblies.values())[0]
 		self._pwr_assembly0 = self._case.get_openmc_assembly(self._assembly0)
 		self._pitch = self._get_pitch()

--- a/v2o/read_xml.py
+++ b/v2o/read_xml.py
@@ -96,7 +96,11 @@ class Case:
 		self.__read_xml()
 		
 		# And now, select a state and use its properties
-		#FIXME: Right now, this just selects the first state encountered
+		###################################################################
+		# FIXME: Right now, this just selects the first state encountered #
+		###################################################################
+		if len(self.states) > 1:
+			raise RuntimeError(f"Multiple states found: {self.states}. Aborting.")
 		self.state = self.states[0]
 		self.materials['mod'] = self.state.mod
 		'''

--- a/v2o/read_xml.py
+++ b/v2o/read_xml.py
@@ -384,12 +384,8 @@ class Case:
 									self.errors += 1
 									
 							# Instantiate an Assembly object and pass it the parameters
-<<<<<<< HEAD:v2o/read_xml.py
 							new_assembly = v2o.Assembly(name=cname, cells=cells, cellmaps=maps, spacergrids=grids,
 							                            params=asmbly_params)
-=======
-							new_assembly = v2o.Assembly(name = cname, cells = cells, cellmaps = maps, spacergrids = grids, params = asmbly_params)
->>>>>>> master:read_xml.py
 							self.assemblies[new_assembly.label] = new_assembly
 						
 					elif name == "STATES":
@@ -630,11 +626,7 @@ class Case:
 			state:		The ParameterList object describing an operating state
 		Output:
 			a_state:	instance of v2o.State
-<<<<<<< HEAD:v2o/read_xml.py
 		"""
-=======
-		'''
->>>>>>> master:read_xml.py
 		key = state.attrib["name"].lower()
 		
 		# Initialize variables
@@ -712,11 +704,7 @@ class Case:
 			is_control:		Whether to instantiate this as a Control object.
 		Output:
 			an_insert:		instance of v2o.Insert
-<<<<<<< HEAD:v2o/read_xml.py
 		"""
-=======
-		'''
->>>>>>> master:read_xml.py
 		in_name = insert.attrib["name"].lower()
 		# dictionary of all independent parameters for this assembly
 		key = in_name; title = in_name


### PR DESCRIPTION
See Issue #7 

@johnnyliu27, this is all I had time for this weekend, but it should help. Basically, Vera-to-OpenMC is finding multiple lattice definitions in the Problem 3b XML input and just returns the first one. I will need to look into the input files and figure out what field tells VERA what lattice to use.

For a quick hack:

 - clone the 'bugfix' branch
 - go to [`AssemblyConversion._set_case_tallies()`](https://github.com/tjlaboss/vera-to-openmc/blob/a9062cdb858570c4bbff34271412606981974876/v2o/__main__.py#L547) (Lines 547-554) 
 - add some logic to pull the exact lattice definition you need

